### PR TITLE
Malloc speedup

### DIFF
--- a/src/C_averaging.c
+++ b/src/C_averaging.c
@@ -41,11 +41,11 @@ double average_profile_in_bin(double Rlo, double Rhi, double*R, int NR, double*p
   gsl_integration_workspace * workspace
     = gsl_integration_workspace_alloc(workspace_size);
 
-  integrand_params*params=malloc(sizeof(integrand_params));
-  params->acc = acc;
-  params->spline = spline;
+  integrand_params params;
+  params.acc = acc;
+  params.spline = spline;
   gsl_function F;
-  F.params=params;
+  F.params = &params;
   double result, err;
   F.function = &ave_integrand;
 
@@ -53,7 +53,6 @@ double average_profile_in_bin(double Rlo, double Rhi, double*R, int NR, double*p
 
   gsl_spline_free(spline),gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
-  free(params);
 
   return 2*result/(Rhi*Rhi-Rlo*Rlo);
 }
@@ -65,11 +64,11 @@ int average_profile_in_bins(double*Redges, int Nedges, double*R, int NR, double*
   gsl_integration_workspace * workspace
     = gsl_integration_workspace_alloc(workspace_size);
 
-  integrand_params*params=malloc(sizeof(integrand_params));
-  params->acc = acc;
-  params->spline = spline;
+  integrand_params params;
+  params.acc = acc;
+  params.spline = spline;
   gsl_function F;
-  F.params=params;
+  F.params = &params;
   double result, err;
   F.function = &ave_integrand;
 
@@ -80,6 +79,5 @@ int average_profile_in_bins(double*Redges, int Nedges, double*R, int NR, double*
   }
   gsl_spline_free(spline),gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
-  free(params);
   return 0;
 }

--- a/src/C_bias.c
+++ b/src/C_bias.c
@@ -32,14 +32,9 @@
  * This is the Tinker et al. (2010) bias model.
  */
 double bias_at_nu(double nu, int delta){
-  double*nus  = malloc(sizeof(double));
-  double*bias = malloc(sizeof(double));
-  nus[0] = nu;
-  bias_at_nu_arr(nus, 1, delta, bias);
-  double result = bias[0];
-  free(nus);
-  free(bias);
-  return result;
+  double bias = 0.0;
+  bias_at_nu_arr(&nu, 1, delta, &bias);
+  return bias;
 }
 
 /**
@@ -52,14 +47,9 @@ double bias_at_nu(double nu, int delta){
  * This is the Tinker et al. (2010) bias model.
  */
 double bias_at_R(double R, int delta, double*k, double*P, int Nk){
-  double*Rs   = malloc(sizeof(double));
-  double*bias = malloc(sizeof(double));
-  Rs[0] = R;
-  bias_at_R_arr(Rs, 1, delta, k, P, Nk, bias);
-  double result = bias[0];
-  free(Rs);
-  free(bias);
-  return result;
+  double bias = 0.0;
+  bias_at_R_arr(&R, 1, delta, k, P, Nk, &bias);
+  return bias;
 }
 
 /**

--- a/src/C_concentration.c
+++ b/src/C_concentration.c
@@ -77,7 +77,7 @@ double Mm_from_Mc(double Mc, void*params){
 double DK15_concentration_at_Mmean(double Mass, double*k, double*P, int Nk, int delta, double n_s,
 				   double Omega_b, double Omega_m, double h, double T_CMB){
   int status;
-  mc_params*pars = (mc_params*)malloc(sizeof(mc_params));
+  mc_params pars;
   double R = pow(Mass/(1.33333333333*M_PI*rhocrit*Omega_m*delta), 0.33333333); //R200m
   double M_lo = Mass/10;
   double M_hi = Mass*10;
@@ -87,20 +87,20 @@ double DK15_concentration_at_Mmean(double Mass, double*k, double*P, int Nk, int 
   gsl_root_fsolver*s = gsl_root_fsolver_alloc(T);
   gsl_function F;
   int iter = 0, max_iter = 100;
-  pars->Mm = Mass;
-  pars->Rm = R;
-  pars->k = k;
-  pars->P = P;
-  pars->Nk = Nk;
-  pars->delta = delta;
-  pars->h = h;
-  pars->n_s = n_s;
-  pars->Omega_b = Omega_b;
-  pars->Omega_m = Omega_m;
-  pars->T_CMB = T_CMB;
+  pars.Mm = Mass;
+  pars.Rm = R;
+  pars.k = k;
+  pars.P = P;
+  pars.Nk = Nk;
+  pars.delta = delta;
+  pars.h = h;
+  pars.n_s = n_s;
+  pars.Omega_b = Omega_b;
+  pars.Omega_m = Omega_m;
+  pars.T_CMB = T_CMB;
   
   F.function = &Mm_from_Mc;
-  F.params = pars;
+  F.params = &pars;
 
   status = gsl_root_fsolver_set(s, &F, M_lo, M_hi);
 
@@ -113,9 +113,8 @@ double DK15_concentration_at_Mmean(double Mass, double*k, double*P, int Nk, int 
     status = gsl_root_test_interval(M_lo, M_hi, 0, 0.001);
   }while(status == GSL_CONTINUE && iter < max_iter);
   
-  cm = pars->cm;
+  cm = pars.cm;
 
-  free(pars);
   gsl_root_fsolver_free(s);
   return cm;
 }

--- a/src/C_density.c
+++ b/src/C_density.c
@@ -50,14 +50,9 @@ int calc_rho_nfw(double*R, int NR, double Mass, double conc, int delta, double o
 }
 
 double rho_einasto_at_R(double R, double Mass, double rhos, double conc, double alpha, int delta, double om){
-  double*Rarr = (double*)malloc(sizeof(double));
-  double*rhoe = (double*)malloc(sizeof(double));
-  Rarr[0] = R;
-  calc_rho_einasto(Rarr, 1, Mass, rhos, conc, alpha, delta, om, rhoe);
-  double result = rhoe[0];
-  free(Rarr);
-  free(rhoe);
-  return result;
+  double rhoe = 0.0;
+  calc_rho_einasto(&R, 1, Mass, rhos, conc, alpha, delta, om, &rhoe);
+  return rhoe;
 }
 
 int calc_rho_einasto(double*R, int NR, double Mass, double rhos, double conc, double alpha, int delta, double om, double*rho_einasto){

--- a/src/C_exclusion.c
+++ b/src/C_exclusion.c
@@ -130,15 +130,9 @@ int xi_1h_at_r_arr(double*r, int Nr, double M, double c,
 
 double xi_1h_at_r(double r, double M, double c,
 		  double rt, double beta, int delta, double Omega_m){
-  double*rs    = malloc(sizeof(double));
-  double*xi_1h = malloc(sizeof(double));
-  double result;
-  rs[0] = r;
-  xi_1h_at_r_arr(rs, 1, M, c, rt, beta, delta, Omega_m, xi_1h);
-  result = xi_1h[0];
-  free(rs);
-  free(xi_1h);
-  return result;
+  double xi_1h = 0.0;
+  xi_1h_at_r_arr(&r, 1, M, c, rt, beta, delta, Omega_m, &xi_1h);
+  return xi_1h;
 }
 
 int xi_2h_at_r_arr(double*r, int Nr, double bias, double*ximm, double*xi2h){
@@ -150,15 +144,9 @@ int xi_2h_at_r_arr(double*r, int Nr, double bias, double*ximm, double*xi2h){
 }
 
 double xi_2h_at_r(double r, double bias, double ximm){
-  double*rs    = malloc(sizeof(double));
-  double*xi_2h = malloc(sizeof(double));
-  double result;
-  rs[0] = r;
-  xi_2h_at_r_arr(rs, 1, bias, &ximm, xi_2h);
-  result = xi_2h[0];
-  free(rs);
-  free(xi_2h);
-  return result;
+  double xi_2h = 0.0;
+  xi_2h_at_r_arr(&r, 1, bias, &ximm, &xi_2h);
+  return xi_2h;
 }
 
 int xi_correction_at_r_arr(double*r, int Nr, double M, double rt,
@@ -188,13 +176,7 @@ int theta_erfc_at_r_arr(double*r, int Nr, double rt, double beta, double*theta){
 }
 
 double theta_erfc_at_r(double r, double rt, double beta){
-  double*rs     = malloc(sizeof(double));
-  double*thetas = malloc(sizeof(double));
-  double result;
-  rs[0] = r;
-  theta_erfc_at_r_arr(rs, 1, rt, beta, thetas);
-  result = thetas[0];
-  free(rs);
-  free(thetas);
-  return result;
+  double thetas = 0.0;
+  theta_erfc_at_r_arr(&r, 1, rt, beta, &thetas);
+  return thetas;
 }

--- a/src/C_massfunction.c
+++ b/src/C_massfunction.c
@@ -21,15 +21,9 @@
 
 ///////////////// G multiplicity function///////////////////
 double G_at_M(double M, double*k, double*P, int Nk, double om, double d, double e, double f, double g){
-  double*Marr = (double*)malloc(sizeof(double));
-  double*G = (double*)malloc(sizeof(double));
-  double result;
-  Marr[0] = M;
-  G_at_M_arr(Marr, 1, k, P, Nk, om, d, e, f, g, G);
-  result = G[0];
-  free(Marr);
-  free(G);
-  return result;
+  double G = 0.0;
+  G_at_M_arr(&M, 1, k, P, Nk, om, d, e, f, g, &G);
+  return G;
 }
 
 int G_at_M_arr(double*M, int NM, double*k, double*P, int Nk, double om, double d, double e, double f, double g, double*G){
@@ -45,15 +39,9 @@ int G_at_M_arr(double*M, int NM, double*k, double*P, int Nk, double om, double d
 }
 
 double G_at_sigma(double sigma, double d, double e, double f, double g){
-  double*sig = (double*)malloc(sizeof(double));
-  double*G = (double*)malloc(sizeof(double));
-  double result;
-  sig[0] = sigma;
-  G_at_sigma_arr(sig, 1, d, e, f, g, G);
-  result = G[0];
-  free(sig);
-  free(G);
-  return result;
+  double G = 0.0;
+  G_at_sigma_arr(&sigma, 1, d, e, f, g, &G);
+  return G;
 }
 
 int G_at_sigma_arr(double*sigma, int Ns, double d, double e, double f, double g, double*G){
@@ -91,15 +79,9 @@ int dndM_sigma2_precomputed(double*M, double*sigma2, double*dsigma2dM, int NM, d
 }
 
 double dndM_at_M(double M, double*k, double*P, int Nk, double om, double d, double e, double f, double g){
-  double*Marr = (double*)malloc(sizeof(double));
-  double*dndM = (double*)malloc(sizeof(double));
-  double result;
-  Marr[0] = M;
-  dndM_at_M_arr(Marr, 1, k, P, Nk, om, d, e, f, g, dndM);
-  result = dndM[0];
-  free(Marr);
-  free(dndM);
-  return result;
+  double dndM = 0.0;
+  dndM_at_M_arr(&M, 1, k, P, Nk, om, d, e, f, g, &dndM);
+  return dndM;
 }
 
 int dndM_at_M_arr(double*M, int NM, double*k, double*P, int Nk, double om, double d, double e, double f, double g, double*dndM){
@@ -123,16 +105,10 @@ int d2ndM2_at_M_arr(double*M, int NM, double*k, double*P, int Nk, double Omega_m
 ///////////////// N in bin functions below ///////////////////
 
 double n_in_bin(double Mlo, double Mhi, double*M, double*dndM, int NM){
-  double*N = (double*)malloc(sizeof(double));
-  double*edges = (double*)malloc(2*sizeof(double));
-  double result;
-  edges[0] = Mlo;
-  edges[1] = Mhi;
-  n_in_bins(edges, 2, M, dndM, NM, N);
-  result = N[0];
-  free(N);
-  free(edges);
-  return result;
+  double edges[2] = { Mlo, Mhi };
+  double N = 0.0;
+  n_in_bins(edges, 2, M, dndM, NM, &N);
+  return N;
 }
 
 int n_in_bins(double*edges, int Nedges, double*M, double*dndM, int NM, double*N){

--- a/src/C_miscentering.c
+++ b/src/C_miscentering.c
@@ -98,15 +98,9 @@ double single_angular_integrand(double theta, void*params){
  *  @return Sigma_mis(R) in h*Msun/pc^2 comoving.
  */
 double Sigma_mis_single_at_R(double R, double*Rs, double*Sigma, int Ns, double M, double conc, int delta, double Omega_m, double Rmis){
-  double*Ra = (double*)malloc(sizeof(double));
-  double*Smis = (double*)malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  Sigma_mis_single_at_R_arr(Ra, 1, Rs, Sigma, Ns, M, conc, delta, Omega_m, Rmis, Smis);
-  result = Smis[0];
-  free(Ra);
-  free(Smis);
-  return result;
+  double Smis = 0.0;
+  Sigma_mis_single_at_R_arr(&R, 1, Rs, Sigma, Ns, M, conc, delta, Omega_m, Rmis, &Smis);
+  return Smis;
 }
 
 /** @brief Miscentered Sigma profile at radius R in Mpc/h comoving.
@@ -133,7 +127,7 @@ int Sigma_mis_single_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns,
   gsl_interp_accel*acc = gsl_interp_accel_alloc();
   gsl_integration_workspace*workspace = gsl_integration_workspace_alloc(workspace_size);
   gsl_integration_workspace*workspace2 = gsl_integration_workspace_alloc(workspace_size);
-  integrand_params*params = malloc(sizeof(integrand_params));
+  integrand_params params;
   gsl_function F;
   double result, err;
   int i;
@@ -142,25 +136,25 @@ int Sigma_mis_single_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns,
     lnRs[i] = log(Rs[i]);
   }
   gsl_spline_init(spline, lnRs, Sigma, Ns);
-  params->acc = acc;
-  params->spline = spline;
-  params->workspace = workspace;
-  params->workspace2 = workspace2;
-  params->M = M;
-  params->conc = conc;
-  params->delta = delta;
-  params->om = Omega_m;
-  params->Rmis = Rmis;
-  params->Rmis2 = Rmis*Rmis;
-  params->rmin = Rs[0];
-  params->rmax = Rs[Ns-1];
-  params->lrmin = log(Rs[0]);
-  params->lrmax = log(Rs[Ns-1]);
+  params.acc = acc;
+  params.spline = spline;
+  params.workspace = workspace;
+  params.workspace2 = workspace2;
+  params.M = M;
+  params.conc = conc;
+  params.delta = delta;
+  params.om = Omega_m;
+  params.Rmis = Rmis;
+  params.Rmis2 = Rmis*Rmis;
+  params.rmin = Rs[0];
+  params.rmax = Rs[Ns-1];
+  params.lrmin = log(Rs[0]);
+  params.lrmax = log(Rs[Ns-1]);
   F.function=&single_angular_integrand;
-  F.params=params;
+  F.params = &params;
   for(i = 0; i < NR; i++){
-    params->Rp  = R[i];
-    params->Rp2 = R[i] * R[i];
+    params.Rp  = R[i];
+    params.Rp2 = R[i] * R[i];
     gsl_integration_qag(&F, 0, M_PI, ABSERR, RELERR, workspace_size, KEY, workspace, &result, &err);
     Sigma_mis[i] = result/M_PI;
   }
@@ -169,7 +163,6 @@ int Sigma_mis_single_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns,
   gsl_integration_workspace_free(workspace);
   gsl_integration_workspace_free(workspace2);
   free(lnRs);
-  free(params);
   return 0;
 }
 
@@ -261,15 +254,9 @@ double angular_integrand(double theta, void*params){
 }
 
 double Sigma_mis_at_R(double R, double*Rs, double*Sigma, int Ns, double M, double conc, int delta, double om, double Rmis, int integrand_switch){
-  double*Ra = (double*)malloc(sizeof(double));
-  double*Sigma_mis = (double*)malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  Sigma_mis_at_R_arr(Ra, 1, Rs, Sigma, Ns, M, conc, delta, om, Rmis, integrand_switch, Sigma_mis);
-  result = Sigma_mis[0];
-  free(Ra);
-  free(Sigma_mis);
-  return result;
+  double Sigma_mis = 0.0;
+  Sigma_mis_at_R_arr(&R, 1, Rs, Sigma, Ns, M, conc, delta, om, Rmis, integrand_switch, &Sigma_mis);
+  return Sigma_mis;
 }
 
 /** @brief Miscentered Sigma profile at radius R in Mpc/h comoving.
@@ -302,7 +289,7 @@ int Sigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, double
   gsl_integration_workspace*workspace2 = gsl_integration_workspace_alloc(workspace_size);
   //Create the integration_params structure, which holds extra information when performing integrals.
   //See the top of this file where the struct is defined.
-  integrand_params*params = malloc(sizeof(integrand_params));
+  integrand_params params;
   //GSL integrals need pointers to the integrands. The variables for these functions are defined here.
   gsl_function F;
   gsl_function F_radial;
@@ -316,20 +303,20 @@ int Sigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, double
   }
   //Create the pline and add all information to the params struct.
   gsl_spline_init(spline, lnRs, Sigma, Ns);
-  params->acc = acc;
-  params->spline = spline;
-  params->workspace = workspace;
-  params->workspace2 = workspace2;
-  params->M = M;
-  params->conc = conc;
-  params->delta = delta;
-  params->om = om;
-  params->Rmis = Rmis;
-  params->Rmis2 = Rmis*Rmis;
-  params->rmin = Rs[0];
-  params->rmax = Rs[Ns-1];
-  params->lrmin = log(Rs[0]);
-  params->lrmax = log(Rs[Ns-1]);
+  params.acc = acc;
+  params.spline = spline;
+  params.workspace = workspace;
+  params.workspace2 = workspace2;
+  params.M = M;
+  params.conc = conc;
+  params.delta = delta;
+  params.om = om;
+  params.Rmis = Rmis;
+  params.Rmis2 = Rmis*Rmis;
+  params.rmin = Rs[0];
+  params.rmax = Rs[Ns-1];
+  params.lrmin = log(Rs[0]);
+  params.lrmax = log(Rs[Ns-1]);
   //The "outer" integral is the angular integral.
   F.function = &angular_integrand;
   //The "inner" integral is radial over R_mis.
@@ -340,13 +327,13 @@ int Sigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, double
     F_radial.function = &exp_radial_integrand;
   }
   //Assign the params struct to the GSL functions.
-  F_radial.params = params;
-  params->F_radial = F_radial;
-  F.params = params;
+  F_radial.params = &params;
+  params.F_radial = F_radial;
+  F.params = &params;
   //Do the integral, with Rp^2 ( precomputed.
   for(i = 0; i < NR; i++){
-    params->Rp  = R[i];
-    params->Rp2 = R[i] * R[i];
+    params.Rp  = R[i];
+    params.Rp2 = R[i] * R[i];
     //The "outer" integral.
     gsl_integration_qag(&F, 0, M_PI, ABSERR, RELERR, workspace_size, KEY, workspace, &result, &err);
     Sigma_mis[i] = result/(M_PI*Rmis*Rmis); //Normalization
@@ -356,7 +343,6 @@ int Sigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, double
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
   gsl_integration_workspace_free(workspace2);
-  free(params);
   free(lnRs);
   return 0; //return success
 }
@@ -397,15 +383,9 @@ double DS_mis_integrand(double lR, void*params){
  *  @return DeltaSigma_mis(R) in h*Msun/pc^2 comoving.
  */
 double DeltaSigma_mis_at_R(double R, double*Rs, double*Sigma_mis, int Ns){
-  double*Ra = (double*)malloc(sizeof(double));
-  double*DSm = (double*)malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  DeltaSigma_mis_at_R_arr(Ra, 1, Rs, Sigma_mis, Ns, DSm);
-  result = DSm[0];
-  free(Ra);
-  free(DSm);
-  return result;
+  double DSm = 0.0;
+  DeltaSigma_mis_at_R_arr(&R, 1, Rs, Sigma_mis, Ns, &DSm);
+  return DSm;
 }
 
 int DeltaSigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, double*DeltaSigma_mis){
@@ -413,7 +393,7 @@ int DeltaSigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, d
   gsl_spline*spline = gsl_spline_alloc(gsl_interp_cspline, Ns);
   gsl_interp_accel*acc = gsl_interp_accel_alloc();
   gsl_integration_workspace* workspace = gsl_integration_workspace_alloc(workspace_size);
-  integrand_params*params=malloc(sizeof(integrand_params));
+  integrand_params params;
   double slope = log(Sigma[0]/Sigma[1])/log(Rs[0]/Rs[1]);
   double intercept = Sigma[0]*pow(Rs[0], -slope);
   double low_part = intercept*pow(Rs[0], slope+2)/(slope+2);
@@ -421,9 +401,9 @@ int DeltaSigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, d
   gsl_function F;
   int i;
   gsl_spline_init(spline, Rs, Sigma, Ns);
-  params->spline = spline;
-  params->acc = acc;
-  F.params = params;
+  params.spline = spline;
+  params.acc = acc;
+  F.params = &params;
   F.function = &DS_mis_integrand;
   for(i = 0; i < NR; i++){
     gsl_integration_qag(&F, lrmin, log(R[i]), ABSERR, RELERR, workspace_size, KEY, workspace, &result, &err);
@@ -431,6 +411,5 @@ int DeltaSigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns, d
   }
   gsl_spline_free(spline),gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
-  free(params);
   return 0;
 }

--- a/src/C_peak_height.c
+++ b/src/C_peak_height.c
@@ -68,15 +68,9 @@ double dsigma2dR_integrand(double lk, void*params){
 
 double sigma2_at_R(double R, double*k, double*P, int Nk){
   //sigma^2(R) for a single value of R
-  double*Rs = (double*)malloc(sizeof(double));
-  double*s2 = (double*)malloc(sizeof(double));
-  double result;
-  Rs[0] = R;
-  sigma2_at_R_arr(Rs, 1, k, P, Nk, s2);
-  result = s2[0];
-  free(Rs);
-  free(s2);
-  return result;
+  double s2 = 0.0;
+  sigma2_at_R_arr(&R, 1, k, P, Nk, &s2);
+  return s2;
 }
 
 double sigma2_at_M(double M, double*k, double*P, int Nk, double om){
@@ -92,29 +86,28 @@ int sigma2_at_R_arr(double*R, int NR,  double*k, double*P, int Nk, double*s2){
   gsl_interp_accel*acc = gsl_interp_accel_alloc();
   gsl_integration_workspace*workspace = gsl_integration_workspace_alloc(workspace_size);
   gsl_function F;
-  integrand_params*params = (integrand_params*)malloc(sizeof(integrand_params));
+  integrand_params params;
   double lkmin = log(k[0]);
   double lkmax = log(k[Nk-1]);
   double result,abserr;
   double denom_inv = 1./(2*M_PI*M_PI);
   int i;
   gsl_spline_init(spline,k,P,Nk);
-  params->spline = spline;
-  params->acc = acc;
-  params->kp = k;
-  params->Pp = P;
-  params->Nk = Nk;
+  params.spline = spline;
+  params.acc = acc;
+  params.kp = k;
+  params.Pp = P;
+  params.Nk = Nk;
   F.function = &sigma2_integrand;
-  F.params = params;
+  F.params = &params;
   for(i = 0; i < NR; i++){
-    params->r = R[i];
+    params.r = R[i];
     gsl_integration_qag(&F, lkmin, lkmax, ABSERR, RELERR, workspace_size, KEY, workspace, &result, &abserr);
     s2[i] = result * denom_inv; //divide by 2pi^2
   }
   gsl_spline_free(spline);
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
-  free(params);
   return 0;
 }
 
@@ -138,44 +131,36 @@ int dsigma2dR_at_R_arr(double*R, int NR, double*k, double*P, int Nk, double*ds2d
   gsl_interp_accel*acc = gsl_interp_accel_alloc();
   gsl_integration_workspace*workspace = gsl_integration_workspace_alloc(workspace_size);
   gsl_function F;
-  integrand_params*params = (integrand_params*)malloc(sizeof(integrand_params));
+  integrand_params params;
   double lkmin = log(k[0]);
   double lkmax = log(k[Nk-1]);
   double result,abserr;
   double denom_inv = 1./(2*M_PI*M_PI);
   int i;
   gsl_spline_init(spline,k,P,Nk);
-  params->spline = spline;
-  params->acc = acc;
-  params->kp = k;
-  params->Pp = P;
-  params->Nk = Nk;
+  params.spline = spline;
+  params.acc = acc;
+  params.kp = k;
+  params.Pp = P;
+  params.Nk = Nk;
   F.function = &dsigma2dR_integrand;
-  F.params = params;
+  F.params = &params;
   for(i = 0; i < NR; i++){
-    params->r = R[i];
+    params.r = R[i];
     gsl_integration_qag(&F, lkmin, lkmax, ABSERR, RELERR, workspace_size, KEY, workspace, &result, &abserr);
     ds2dR[i] = result * denom_inv; //divide by 2pi^2
   }
   gsl_spline_free(spline);
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
-  free(params);
-  return 0;
   return 0;
 }
 
 double dsigma2dR_at_R(double R, double*k, double*P, int Nk){
   //sigma^2(R) for a single value of R
-  double*Rs = (double*)malloc(sizeof(double));
-  double*ds2dR = (double*)malloc(sizeof(double));
-  double result;
-  Rs[0] = R;
-  dsigma2dR_at_R_arr(Rs, 1, k, P, Nk, ds2dR);
-  result = ds2dR[0];
-  free(Rs);
-  free(ds2dR);
-  return result;
+  double ds2dR = 0.0;
+  dsigma2dR_at_R_arr(&R, 1, k, P, Nk, &ds2dR);
+  return ds2dR;
 }
 
 /* The derivative with respect to M of sigma^2. This is needed for the mass
@@ -200,15 +185,9 @@ int dsigma2dM_at_M_arr(double*M, int NM, double*k, double*P, int Nk, double Omeg
 }
 
 double dsigma2dM_at_M(double M, double*k, double*P, int Nk, double Omega_m){
-  double*Ms = (double*)malloc(sizeof(double));
-  double*ds2dM = (double*)malloc(sizeof(double));
-  double result;
-  Ms[0] = M;
-  dsigma2dR_at_R_arr(Ms, 1, k, P, Nk, ds2dM);
-  result = ds2dM[0];
-  free(Ms);
-  free(ds2dM);
-  return result;
+  double ds2dM = 0.0;
+  dsigma2dR_at_R_arr(&M, 1, k, P, Nk, &ds2dM);
+  return ds2dM;
 }
 
 ///////////PEAK HEIGHT FUNCTIONS///////////

--- a/src/C_profile_derivatives.c
+++ b/src/C_profile_derivatives.c
@@ -27,15 +27,9 @@
 #define RELERR 1.8e-4
 
 double drho_nfw_dr_at_R(double R, double Mass, double conc, int delta, double Omega_m){
-  double*Rarr = (double*)malloc(sizeof(double));
-  double*drhodr  = (double*)malloc(sizeof(double));
-  double result;
-  Rarr[0] = R;
-  drho_nfw_dr_at_R_arr(Rarr, 1, Mass, conc, delta, Omega_m, drhodr);
-  result = drhodr[0];
-  free(Rarr);
-  free(drhodr);
-  return result;
+  double drhodr = 0.0;
+  drho_nfw_dr_at_R_arr(&R, 1, Mass, conc, delta, Omega_m, &drhodr);
+  return drhodr;
 }
 
 int drho_nfw_dr_at_R_arr(double*R, int NR, double Mass, double conc,
@@ -94,26 +88,19 @@ double integrand_dxi_mm_dr_SINE(double k, void*params){
 }
 
 double dxi_mm_dr_at_R(double R, double*k, double*P, int Nk){
-  double*Rarr = (double*)malloc(sizeof(double));
-  double*dxidr  = (double*)malloc(sizeof(double));
-  double result;
-  Rarr[0] = R;
-  dxi_mm_dr_at_R_arr(Rarr, 1, k, P, Nk, dxidr);
-  result = dxidr[0];
-  free(Rarr);
-  free(dxidr);
-  return result;
+  double dxidr = 0.0;
+  dxi_mm_dr_at_R_arr(&R, 1, k, P, Nk, &dxidr);
+  return dxidr;
 }
 
 int dxi_mm_dr_at_R_arr(double*R, int NR, double*k, double*P, int Nk, double*dxidr){
   static int init_flag = 0;
   static gsl_interp_accel*acc;
   static gsl_integration_workspace*workspace;
-  static integrand_params_profile_derivs*params;
+  static integrand_params_profile_derivs params;
   if (!init_flag){
     acc = gsl_interp_accel_alloc();
     workspace = gsl_integration_workspace_alloc(workspace_size);
-    params = malloc(sizeof(integrand_params_profile_derivs));
     init_flag = 1;
   }
   
@@ -127,11 +114,11 @@ int dxi_mm_dr_at_R_arr(double*R, int NR, double*k, double*P, int Nk, double*dxid
   int i;
   int status;
   gsl_spline_init(Pspl, k, P, Nk);
-  params->acc = acc;
-  params->spline = Pspl;
-  params->kp = k;
-  params->Pp = P;
-  params->Nk = Nk;
+  params.acc = acc;
+  params.spline = Pspl;
+  params.kp = k;
+  params.Pp = P;
+  params.Nk = Nk;
 
   gsl_function F_cosine;
   gsl_function F_sine;
@@ -139,8 +126,8 @@ int dxi_mm_dr_at_R_arr(double*R, int NR, double*k, double*P, int Nk, double*dxid
   F_cosine.function = &integrand_dxi_mm_dr_COSINE;
   F_sine.function   = &integrand_dxi_mm_dr_SINE;
 
-  F_cosine.params = params;
-  F_sine.params   = params;
+  F_cosine.params = &params;
+  F_sine.params   = &params;
 
   wf_cosine = gsl_integration_qawo_table_alloc(R[0], kmax-kmin, GSL_INTEG_COSINE,
 					       (size_t)workspace_num);
@@ -153,7 +140,7 @@ int dxi_mm_dr_at_R_arr(double*R, int NR, double*k, double*P, int Nk, double*dxid
       printf("Error in dxi_mm_dr in qawo_table_set.\n");
       exit(-1);
     }
-    params->r=R[i];
+    params.r=R[i];
     status = gsl_integration_qawo(&F_cosine, kmin, ABSERR, RELERR, (size_t)workspace_num,
 				  workspace, wf_cosine, &result_cosine, &err);
     status = gsl_integration_qawo(&F_sine, kmin, ABSERR, RELERR, (size_t)workspace_num,
@@ -170,7 +157,6 @@ int dxi_mm_dr_at_R_arr(double*R, int NR, double*k, double*P, int Nk, double*dxid
   gsl_integration_qawo_table_free(wf_cosine);
   gsl_integration_qawo_table_free(wf_sine);
   //These are now static.
-  //free(params);
   //gsl_interp_accel_free(acc);
   //gsl_integration_workspace_free(workspace);
 

--- a/src/C_xi.c
+++ b/src/C_xi.c
@@ -28,15 +28,9 @@
  *  @return NFW halo correlation function.
  */
 double xi_nfw_at_R(double R, double Mass, double conc, int delta, double om){
-  double*Rarr = (double*)malloc(sizeof(double));
-  double*xi  = (double*)malloc(sizeof(double));
-  double result;
-  Rarr[0] = R;
-  calc_xi_nfw(Rarr, 1, Mass, conc, delta, om, xi);
-  result = xi[0];
-  free(Rarr);
-  free(xi);
-  return result;
+  double xi = 0.0;
+  calc_xi_nfw(&R, 1, Mass, conc, delta, om, &xi);
+  return xi;
 }
 
 int calc_xi_nfw(double*R, int NR, double Mass, double conc, int delta, double om, double*xi_nfw){
@@ -68,15 +62,9 @@ double rhos_einasto_at_M(double Mass, double conc, double alpha, int delta, doub
 }
 
 double xi_einasto_at_R(double R, double Mass, double rhos, double conc, double alpha, int delta, double om){
-  double*Rarr = malloc(sizeof(double));
-  double*xi  = malloc(sizeof(double));
-  double result;
-  Rarr[0] = R;
-  calc_xi_einasto(Rarr, 1, Mass, rhos, conc, alpha, delta, om, xi);
-  result = xi[0];
-  free(Rarr);
-  free(xi);
-  return result;
+  double xi = 0.0;
+  calc_xi_einasto(&R, 1, Mass, rhos, conc, alpha, delta, om, &xi);
+  return xi;
 }
 
 int calc_xi_einasto(double*R, int NR, double Mass, double rhos, double conc, double alpha, int delta, double om, double*xi_einasto){
@@ -196,15 +184,9 @@ int calc_xi_mm(double*R, int NR, double*k, double*P, int Nk, double*xi, int N, d
 ///////Functions for calc_xi_mm/////////
 
 double xi_mm_at_R(double R, double*k, double*P, int Nk, int N, double h){
-  double*Ra = malloc(sizeof(double));
-  double*xi = malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  calc_xi_mm(Ra, 1, k, P, Nk, xi, N, h);
-  result = xi[0];
-  free(Ra);
-  free(xi);
-  return result;
+  double xi = 0.0;
+  calc_xi_mm(&R, 1, k, P, Nk, &xi, N, h);
+  return xi;
 }
 
 //////////////////////////////////////////
@@ -244,7 +226,7 @@ int calc_xi_mm_exact(double*R, int NR, double*k, double*P, int Nk, double*xi){
   gsl_interp_accel*acc= gsl_interp_accel_alloc();
   gsl_integration_workspace*workspace = gsl_integration_workspace_alloc(workspace_size);
   gsl_integration_qawo_table*wf;
-  integrand_params_xi_mm_exact*params=malloc(sizeof(integrand_params_xi_mm_exact));
+  integrand_params_xi_mm_exact params;
   gsl_function F;
   double kmax = 4e3;
   double kmin = 5e-8;
@@ -252,14 +234,14 @@ int calc_xi_mm_exact(double*R, int NR, double*k, double*P, int Nk, double*xi){
   int i;
   int status;
   gsl_spline_init(Pspl, k, P, Nk);
-  params->acc = acc;
-  params->spline = Pspl;
-  params->kp = k;
-  params->Pp = P;
-  params->Nk = Nk;
+  params.acc = acc;
+  params.spline = Pspl;
+  params.kp = k;
+  params.Pp = P;
+  params.Nk = Nk;
 
-  F.function=&integrand_xi_mm_exact;
-  F.params=params;
+  F.function = &integrand_xi_mm_exact;
+  F.params = &params;
 
   wf = gsl_integration_qawo_table_alloc(R[0], kmax-kmin, GSL_INTEG_SINE, (size_t)workspace_num);
   for(i = 0; i < NR; i++){
@@ -268,7 +250,7 @@ int calc_xi_mm_exact(double*R, int NR, double*k, double*P, int Nk, double*xi){
       printf("Error in calc_xi_mm_exact, first integral.\n");
       exit(-1);
     }
-    params->r=R[i];
+    params.r=R[i];
     status = gsl_integration_qawo(&F, kmin, ABSERR, RELERR, (size_t)workspace_num, workspace, wf, &result, &err);
     if (status){
       printf("Error in calc_xi_mm_exact, second integral.\n");
@@ -278,7 +260,6 @@ int calc_xi_mm_exact(double*R, int NR, double*k, double*P, int Nk, double*xi){
     xi[i] = result/(M_PI*M_PI*2);
   }
 
-  free(params);
   gsl_spline_free(Pspl);
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
@@ -288,15 +269,9 @@ int calc_xi_mm_exact(double*R, int NR, double*k, double*P, int Nk, double*xi){
 }
 
 double xi_mm_at_R_exact(double R, double*k, double*P, int Nk){
-  double*Ra = malloc(sizeof(double));
-  double*xi = malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  calc_xi_mm_exact(Ra, 1, k, P, Nk, xi);
-  result = xi[0];
-  free(Ra);
-  free(xi);
-  return result;
+  double xi = 0.0;
+  calc_xi_mm_exact(&R, 1, k, P, Nk, &xi);
+  return xi;
 }
 
 /*
@@ -343,15 +318,9 @@ int calc_xi_DK(double*R, int NR, double M, double rhos, double conc, double be, 
 }
 
 double xi_DK(double R, double M, double rhos, double conc, double be, double se, double alpha, double beta, double gamma, int delta, double*k, double*P, int Nk, double om){
-  double*Ra = malloc(sizeof(double));
-  double*xi = malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  calc_xi_DK(Ra, 1, M, rhos, conc, be, se, alpha, beta, gamma, delta, k, P, Nk, om, xi);
-  result = xi[0];
-  free(Ra);
-  free(xi);
-  return result;
+  double xi = 0.0;
+  calc_xi_DK(&R, 1, M, rhos, conc, be, se, alpha, beta, gamma, delta, k, P, Nk, om, &xi);
+  return xi;
 }
 
 //////////////////////////////
@@ -397,15 +366,9 @@ int calc_xi_DK_app1(double*R, int NR, double M, double rhos, double conc, double
 }
 
 double xi_DK_app1(double R, double M, double rhos, double conc, double be, double se, double alpha, double beta, double gamma, int delta, double*k, double*P, int Nk, double om, double bias, double*xi_mm){
-  double*Ra = malloc(sizeof(double));
-  double*xi = malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  calc_xi_DK_app1(Ra, 1, M, rhos, conc, be, se, alpha, beta, gamma, delta, k, P, Nk, om, bias, xi_mm, xi);
-  result = xi[0];
-  free(Ra);
-  free(xi);
-  return result;
+  double xi = 0.0;
+  calc_xi_DK_app1(&R, 1, M, rhos, conc, be, se, alpha, beta, gamma, delta, k, P, Nk, om, bias, xi_mm, &xi);
+  return xi;
 }
 
 //////////////////////////////
@@ -451,14 +414,7 @@ int calc_xi_DK_app2(double*R, int NR, double M, double rhos, double conc, double
 }
 
 double xi_DK_app2(double R, double M, double rhos, double conc, double be, double se, double alpha, double beta, double gamma, int delta, double*k, double*P, int Nk, double om, double bias, double*xi_mm){
-  double*Ra = malloc(sizeof(double));
-  double*xi = malloc(sizeof(double));
-  double result;
-  Ra[0] = R;
-  calc_xi_DK_app2(Ra, 1, M, rhos, conc, be, se, alpha, beta, gamma, delta, k, P, Nk, om, bias, xi_mm, xi);
-  result = xi[0];
-  free(Ra);
-  free(xi);
-  return result;
-
+  double xi = 0.0;
+  calc_xi_DK_app2(&R, 1, M, rhos, conc, be, se, alpha, beta, gamma, delta, k, P, Nk, om, bias, xi_mm, &xi);
+  return xi;
 }


### PR DESCRIPTION
In some places, things were heap allocated that don't need to be. Changing them to stack allocated made a significant speedup in our case.