### PR TITLE
Malloc speedup

### DIFF
--- a/src/C_averaging.c
+++ b/src/C_averaging.c
@@ -37,23 +37,22 @@ double ave_integrand(double lR, void*params){
 
 int average_profile_in_bins(double*Redges, int Nedges, double*R, int NR,
 			    double*profile, double*ave_profile){
-  int i;
-  gsl_spline*spline = gsl_spline_alloc(gsl_interp_cspline, NR);
-  gsl_interp_accel*acc= gsl_interp_accel_alloc();
-  gsl_integration_workspace * ws = gsl_integration_workspace_alloc(workspace_size);
-  integrand_params*params=malloc(sizeof(integrand_params));
+  gsl_spline *spline = gsl_spline_alloc(gsl_interp_cspline, NR);
+  gsl_interp_accel *acc = gsl_interp_accel_alloc();
+  gsl_integration_workspace *ws = gsl_integration_workspace_alloc(workspace_size);
   gsl_function F;
   double result, err;
 
   gsl_spline_init(spline, R, profile, NR);
 
-  params->acc = acc;
-  params->spline = spline;
-  F.params = params;
+  integrand_params params;
+  params.acc = acc;
+  params.spline = spline;
+  F.params = &params;
   F.function = &ave_integrand;
 
   //Loop over bins and compute the average
-  for(i = 0; i < Nedges-1; i++){
+  for(int i = 0; i < Nedges-1; i++){
     gsl_integration_qag(&F, log(Redges[i]), log(Redges[i+1]), ABSERR, RELERR,
 			workspace_size, 6, ws, &result, &err);
     ave_profile[i] = 2*result/(Redges[i+1]*Redges[i+1]-Redges[i]*Redges[i]);
@@ -63,6 +62,5 @@ int average_profile_in_bins(double*Redges, int Nedges, double*R, int NR,
   gsl_spline_free(spline);
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(ws);
-  free(params);
   return 0;
 }

--- a/src/C_concentration.c
+++ b/src/C_concentration.c
@@ -78,7 +78,7 @@ double DK15_concentration_at_Mmean(double Mass, double*k, double*Plin, int Nk, i
 				   double n_s,double Omega_b, double Omega_m,
 				   double h, double T_CMB){
   int status;
-  mc_params*pars = (mc_params*)malloc(sizeof(mc_params));
+  mc_params pars;
   double R = pow(Mass/(1.33333333333*M_PI*rhocrit*Omega_m*delta), 0.33333333); //R200m
   double M_lo = Mass/10;
   double M_hi = Mass*10;
@@ -88,20 +88,20 @@ double DK15_concentration_at_Mmean(double Mass, double*k, double*Plin, int Nk, i
   gsl_root_fsolver*s = gsl_root_fsolver_alloc(T);
   gsl_function F;
   int iter = 0, max_iter = 100;
-  pars->Mm = Mass;
-  pars->Rm = R;
-  pars->k = k;
-  pars->Plin = Plin;
-  pars->Nk = Nk;
-  pars->delta = delta;
-  pars->h = h;
-  pars->n_s = n_s;
-  pars->Omega_b = Omega_b;
-  pars->Omega_m = Omega_m;
-  pars->T_CMB = T_CMB;
+  pars.Mm = Mass;
+  pars.Rm = R;
+  pars.k = k;
+  pars.Plin = Plin;
+  pars.Nk = Nk;
+  pars.delta = delta;
+  pars.h = h;
+  pars.n_s = n_s;
+  pars.Omega_b = Omega_b;
+  pars.Omega_m = Omega_m;
+  pars.T_CMB = T_CMB;
   
   F.function = &Mm_from_Mc;
-  F.params = pars;
+  F.params = &pars;
 
   status = gsl_root_fsolver_set(s, &F, M_lo, M_hi);
 
@@ -115,9 +115,8 @@ double DK15_concentration_at_Mmean(double Mass, double*k, double*Plin, int Nk, i
     status = gsl_root_test_interval(M_lo, M_hi, 0, 0.001);
   }while(status == GSL_CONTINUE && iter < max_iter);
   
-  cm = pars->cm;
+  cm = pars.cm;
 
-  free(pars);
   gsl_root_fsolver_free(s);
   return cm;
 }

--- a/src/C_miscentering.c
+++ b/src/C_miscentering.c
@@ -111,38 +111,37 @@ int Sigma_mis_single_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns,
   static gsl_spline*spline = NULL;
   static gsl_interp_accel*acc = NULL;
   static gsl_integration_workspace*workspace = NULL;
-  static integrand_params*params = NULL;
+  static integrand_params params;
   if (init_flag == 0){
     init_flag = 1;
     spline = gsl_spline_alloc(gsl_interp_cspline, Ns);
     acc = gsl_interp_accel_alloc();
     workspace = gsl_integration_workspace_alloc(workspace_size);
-    params = malloc(sizeof(integrand_params));
   }
 
   gsl_spline_init(spline, lnRs, Sigma, Ns);
 
-  params->acc = acc;
-  params->spline = spline;
-  params->workspace = workspace;
-  params->M = M;
-  params->conc = conc;
-  params->delta = delta;
-  params->Omega_m = Omega_m;
-  params->Rmis = Rmis;
-  params->Rmis2 = Rmis*Rmis;
-  params->rmin = Rs[0];
-  params->rmax = Rs[Ns-1];
-  params->lrmin = log(Rs[0]);
-  params->lrmax = log(Rs[Ns-1]);
+  params.acc = acc;
+  params.spline = spline;
+  params.workspace = workspace;
+  params.M = M;
+  params.conc = conc;
+  params.delta = delta;
+  params.Omega_m = Omega_m;
+  params.Rmis = Rmis;
+  params.Rmis2 = Rmis*Rmis;
+  params.rmin = Rs[0];
+  params.rmax = Rs[Ns-1];
+  params.lrmin = log(Rs[0]);
+  params.lrmax = log(Rs[Ns-1]);
 
   //Angular integral
-  F.function=&single_angular_integrand;
-  F.params=params;
+  F.function = &single_angular_integrand;
+  F.params = &params;
   
   for(i = 0; i < NR; i++){
-    params->Rp  = R[i];
-    params->Rp2 = R[i] * R[i];
+    params.Rp  = R[i];
+    params.Rp2 = R[i] * R[i];
     gsl_integration_qag(&F, 0, M_PI, ABSERR, RELERR, workspace_size,
 			KEY, workspace, &result, &err);
     Sigma_mis[i] = result/M_PI;
@@ -272,32 +271,31 @@ int Sigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns,
   static gsl_interp_accel*acc = NULL;
   static gsl_integration_workspace*workspace = NULL;
   static gsl_integration_workspace*workspace2 = NULL;
-  static integrand_params*params = NULL;
+  static integrand_params params;
   if (init_flag == 0){
     init_flag = 1;
     spline = gsl_spline_alloc(gsl_interp_cspline, Ns);
     acc = gsl_interp_accel_alloc();
     workspace = gsl_integration_workspace_alloc(workspace_size);
     workspace2 = gsl_integration_workspace_alloc(workspace_size);
-    params = malloc(sizeof(integrand_params));
   }
 
   gsl_spline_init(spline, lnRs, Sigma, Ns);
 
-  params->spline = spline;
-  params->acc = acc;
-  params->workspace = workspace;
-  params->workspace2 = workspace2;
-  params->M = M;
-  params->conc = conc;
-  params->delta = delta;
-  params->Omega_m = Omega_m;
-  params->Rmis = Rmis;
-  params->Rmis2 = Rmis*Rmis;
-  params->rmin = Rs[0];
-  params->rmax = Rs[Ns-1];
-  params->lrmin = log(Rs[0]);
-  params->lrmax = log(Rs[Ns-1]);
+  params.spline = spline;
+  params.acc = acc;
+  params.workspace = workspace;
+  params.workspace2 = workspace2;
+  params.M = M;
+  params.conc = conc;
+  params.delta = delta;
+  params.Omega_m = Omega_m;
+  params.Rmis = Rmis;
+  params.Rmis2 = Rmis*Rmis;
+  params.rmin = Rs[0];
+  params.rmax = Rs[Ns-1];
+  params.lrmin = log(Rs[0]);
+  params.lrmax = log(Rs[Ns-1]);
   
   //Angular integral
   F.function = &angular_integrand;
@@ -313,14 +311,14 @@ int Sigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma, int Ns,
   }
   
   //Assign the params struct to the GSL functions.
-  F_radial.params = params;
-  params->F_radial = F_radial;
-  F.params = params;
+  F_radial.params = &params;
+  params.F_radial = F_radial;
+  F.params = &params;
   
   //Angular integral first
   for(i = 0; i < NR; i++){
-    params->Rp  = R[i];
-    params->Rp2 = R[i] * R[i]; //Optimization
+    params.Rp  = R[i];
+    params.Rp2 = R[i] * R[i]; //Optimization
     
     gsl_integration_qag(&F, 0, M_PI, ABSERR, RELERR, workspace_size,
 			KEY, workspace, &result, &err);
@@ -384,20 +382,19 @@ int DeltaSigma_mis_at_R_arr(double*R, int NR, double*Rs, double*Sigma_mis, int N
   static gsl_spline*spline = NULL;
   static gsl_interp_accel*acc = NULL;
   static gsl_integration_workspace*workspace = NULL;
-  static integrand_params*params = NULL;
+  static integrand_params params;
   if (init_flag == 0){
     init_flag = 1;
     spline = gsl_spline_alloc(gsl_interp_cspline, Ns);
     acc = gsl_interp_accel_alloc();
     workspace = gsl_integration_workspace_alloc(workspace_size);
-    params = malloc(sizeof(integrand_params));
   }
 
   gsl_spline_init(spline, Rs, Sigma_mis, Ns);
   
-  params->spline = spline;
-  params->acc = acc;
-  F.params = params;
+  params.spline = spline;
+  params.acc = acc;
+  F.params = &params;
   F.function = &DS_mis_integrand;
 
   for(i = 0; i < NR; i++){

--- a/src/C_peak_height.c
+++ b/src/C_peak_height.c
@@ -69,14 +69,8 @@ double dsigma2dR_integrand(double lk, void*params){
 
 double sigma2_at_R(double R, double*k, double*P, int Nk){
   //sigma^2(R) for a single value of R
-  double*Rs = (double*)malloc(sizeof(double));
-  double*s2 = (double*)malloc(sizeof(double));
   double result;
-  Rs[0] = R;
-  sigma2_at_R_arr(Rs, 1, k, P, Nk, s2);
-  result = s2[0];
-  free(Rs);
-  free(s2);
+  sigma2_at_R_arr(&R, 1, k, P, Nk, &result);
   return result;
 }
 
@@ -93,22 +87,22 @@ int sigma2_at_R_arr(double*R, int NR,  double*k, double*P, int Nk, double*s2){
   gsl_interp_accel*acc = gsl_interp_accel_alloc();
   gsl_integration_workspace*workspace = gsl_integration_workspace_alloc(workspace_size);
   gsl_function F;
-  integrand_params*params = (integrand_params*)malloc(sizeof(integrand_params));
+  integrand_params params;
   double lkmin = log(k[0]);
   double lkmax = log(k[Nk-1]);
   double result,abserr;
   double denom_inv = 1./(2*M_PI*M_PI);
   int i;
   gsl_spline_init(spline,k,P,Nk);
-  params->spline = spline;
-  params->acc = acc;
-  params->kp = k;
-  params->Pp = P;
-  params->Nk = Nk;
+  params.spline = spline;
+  params.acc = acc;
+  params.kp = k;
+  params.Pp = P;
+  params.Nk = Nk;
   F.function = &sigma2_integrand;
-  F.params = params;
+  F.params = &params;
   for(i = 0; i < NR; i++){
-    params->r = R[i];
+    params.r = R[i];
     gsl_integration_qag(&F, lkmin, lkmax, ABSERR, RELERR,
 			workspace_size, KEY, workspace, &result, &abserr);
     s2[i] = result * denom_inv; //divide by 2pi^2
@@ -116,7 +110,6 @@ int sigma2_at_R_arr(double*R, int NR,  double*k, double*P, int Nk, double*s2){
   gsl_spline_free(spline);
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
-  free(params);
   return 0;
 }
 
@@ -142,7 +135,7 @@ int dsigma2dR_at_R_arr(double*R, int NR, double*k, double*P, int Nk,
   gsl_interp_accel*acc = gsl_interp_accel_alloc();
   gsl_integration_workspace*workspace = gsl_integration_workspace_alloc(workspace_size);
   gsl_function F;
-  integrand_params*params = (integrand_params*)malloc(sizeof(integrand_params));
+  integrand_params params;
   double lkmin = log(k[0]);
   double lkmax = log(k[Nk-1]);
   double result,abserr;
@@ -152,15 +145,15 @@ int dsigma2dR_at_R_arr(double*R, int NR, double*k, double*P, int Nk,
   double denom_inv = 1./(M_PI*M_PI);
   int i;
   gsl_spline_init(spline,k,P,Nk);
-  params->spline = spline;
-  params->acc = acc;
-  params->kp = k;
-  params->Pp = P;
-  params->Nk = Nk;
+  params.spline = spline;
+  params.acc = acc;
+  params.kp = k;
+  params.Pp = P;
+  params.Nk = Nk;
   F.function = &dsigma2dR_integrand;
-  F.params = params;
+  F.params = &params;
   for(i = 0; i < NR; i++){
-    params->r = R[i];
+    params.r = R[i];
     gsl_integration_qag(&F, lkmin, lkmax, ABSERR, RELERR,
 			workspace_size, KEY, workspace, &result, &abserr);
     ds2dR[i] = result * denom_inv; //divide by 2pi^2
@@ -168,21 +161,14 @@ int dsigma2dR_at_R_arr(double*R, int NR, double*k, double*P, int Nk,
   gsl_spline_free(spline);
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
-  free(params);
   return 0;
 }
 
 double dsigma2dR_at_R(double R, double*k, double*P, int Nk){
   //sigma^2(R) for a single value of R
-  double*Rs = (double*)malloc(sizeof(double));
-  double*ds2dR = (double*)malloc(sizeof(double));
-  double result;
-  Rs[0] = R;
-  dsigma2dR_at_R_arr(Rs, 1, k, P, Nk, ds2dR);
-  result = ds2dR[0];
-  free(Rs);
-  free(ds2dR);
-  return result;
+  double ds2dR;
+  dsigma2dR_at_R_arr(&R, 1, k, P, Nk, &ds2dR);
+  return ds2dR;
 }
 
 /* The derivative with respect to M of sigma^2. This is needed for the mass
@@ -209,15 +195,9 @@ int dsigma2dM_at_M_arr(double*M, int NM, double*k, double*P, int Nk,
 }
 
 double dsigma2dM_at_M(double M, double*k, double*P, int Nk, double Omega_m){
-  double*Ms = (double*)malloc(sizeof(double));
-  double*ds2dM = (double*)malloc(sizeof(double));
-  double result;
-  Ms[0] = M;
-  dsigma2dR_at_R_arr(Ms, 1, k, P, Nk, ds2dM);
-  result = ds2dM[0];
-  free(Ms);
-  free(ds2dM);
-  return result;
+  double ds2dM;
+  dsigma2dR_at_R_arr(&M, 1, k, P, Nk, &ds2dM);
+  return ds2dM;
 }
 
 ///////////PEAK HEIGHT FUNCTIONS///////////

--- a/src/C_xi.c
+++ b/src/C_xi.c
@@ -27,15 +27,9 @@
  *  @return NFW halo correlation function.
  */
 double xi_nfw_at_r(double r, double Mass, double conc, int delta, double om){
-  double*rarr = (double*)malloc(sizeof(double));
-  double*xi  = (double*)malloc(sizeof(double));
-  double result;
-  rarr[0] = r;
-  calc_xi_nfw(rarr, 1, Mass, conc, delta, om, xi);
-  result = xi[0];
-  free(rarr);
-  free(xi);
-  return result;
+  double xi;
+  calc_xi_nfw(&r, 1, Mass, conc, delta, om, &xi);
+  return xi;
 }
 
 int calc_xi_nfw(double*r, int Nr, double Mass, double conc, int delta, double om, double*xi_nfw){
@@ -222,15 +216,15 @@ int calc_xi_mm_exact(double*r, int Nr, double*k, double*P, int Nk, double*xi){
   gsl_integration_workspace*workspace = gsl_integration_workspace_alloc(workspace_size);
   gsl_integration_qawo_table*wf;
 
-  integrand_params_xi_mm_exact*params=malloc(sizeof(integrand_params_xi_mm_exact));
-  params->acc = acc;
-  params->spline = Pspl;
-  params->kp = k;
-  params->Pp = P;
-  params->Nk = Nk;
+  integrand_params_xi_mm_exact params;
+  params.acc = acc;
+  params.spline = Pspl;
+  params.kp = k;
+  params.Pp = P;
+  params.Nk = Nk;
 
-  F.function=&integrand_xi_mm_exact;
-  F.params=params;
+  F.function = &integrand_xi_mm_exact;
+  F.params = &params;
 
   wf = gsl_integration_qawo_table_alloc(r[0], kmax-kmin, GSL_INTEG_SINE, (size_t)workspace_num);
   for(i = 0; i < Nr; i++){
@@ -239,7 +233,7 @@ int calc_xi_mm_exact(double*r, int Nr, double*k, double*P, int Nk, double*xi){
       printf("Error in calc_xi_mm_exact, first integral.\n");
       exit(-1);
     }
-    params->r=r[i];
+    params.r=r[i];
     status = gsl_integration_qawo(&F, kmin, ABSERR, RELERR, (size_t)workspace_num,
 				  workspace, wf, &result, &err);
     if (status){
@@ -250,7 +244,6 @@ int calc_xi_mm_exact(double*r, int Nr, double*k, double*P, int Nk, double*xi){
     xi[i] = result/(M_PI*M_PI*2);
   }
 
-  free(params);
   gsl_spline_free(Pspl);
   gsl_interp_accel_free(acc);
   gsl_integration_workspace_free(workspace);
@@ -260,15 +253,9 @@ int calc_xi_mm_exact(double*r, int Nr, double*k, double*P, int Nk, double*xi){
 }
 
 double xi_mm_at_r_exact(double r, double*k, double*P, int Nk){
-  double*ra = malloc(sizeof(double));
-  double*xi = malloc(sizeof(double));
-  double result;
-  ra[0] = r;
-  calc_xi_mm_exact(ra, 1, k, P, Nk, xi);
-  result = xi[0];
-  free(ra);
-  free(xi);
-  return result;
+  double xi;
+  calc_xi_mm_exact(&r, 1, k, P, Nk, &xi);
+  return xi;
 }
 
 /*


### PR DESCRIPTION
Some wrapper functions used malloc()/free() when they did not need to. Making variables stack allocated instead can bring a speed boost.