### PR TITLE
gcc 4.8 compatability

### DIFF
--- a/src/C_averaging.c
+++ b/src/C_averaging.c
@@ -52,7 +52,8 @@ int average_profile_in_bins(double*Redges, int Nedges, double*R, int NR,
   F.function = &ave_integrand;
 
   //Loop over bins and compute the average
-  for(int i = 0; i < Nedges-1; i++){
+  int i;
+  for(i = 0; i < Nedges-1; i++){
     gsl_integration_qag(&F, log(Redges[i]), log(Redges[i+1]), ABSERR, RELERR,
 			workspace_size, 6, ws, &result, &err);
     ave_profile[i] = 2*result/(Redges[i+1]*Redges[i+1]-Redges[i]*Redges[i]);

--- a/src/C_sigma_reconstruction.c
+++ b/src/C_sigma_reconstruction.c
@@ -35,12 +35,13 @@ int Sigma_REC_from_DeltaSigma(double dlnR, double*DeltaSigma, int N,
     1/2s on the edges and 1s in the middle)
    */
   //Loop over Sigma elements; i.e. rows
-  for(int i = 0; i < N-1; i++){
+  int i, j;
+  for(i = 0; i < N-1; i++){
     Sigma[i] = -DeltaSigma[i]; //Not sure if this is positive or negative
     
     //Loop over DeltaSigma elements; i.e. columns
-    //for(int j = N-2-i; j < N; j++){
-    for(int j = i; j < N; j++){
+    //for(j = N-2-i; j < N; j++){
+    for(j = i; j < N; j++){
       Sigma[i] -= 2*dlnR*DeltaSigma[j];
       //Downweight the first and last contributions (midpoint formula)
       //if ((j == N-2-i) || (j == N-1)){


### PR DESCRIPTION
This PR simply moves initialization of the iteration variables to outside of the for loops in the C code. This allows the code to be compiled with gcc 4.8 without additional compiler flags.

This issue came up as setup.py uses the version of gcc used to install python. While easy to fix locally, much harder to fix on the fly in continuous integration systems.